### PR TITLE
Make caller nillable

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,14 +4,14 @@ type Error interface {
 	error
 	Cause() error
 	Severity() Severity
-	Caller() Caller
+	Caller() *Caller
 	Enrich(args ...interface{})
-	setCaller(caller Caller)
+	setCaller(caller *Caller)
 }
 
 type BaseError struct {
 	message  string
-	caller   Caller
+	caller   *Caller
 	severity Severity
 	cause    error
 }
@@ -28,7 +28,7 @@ func (e *BaseError) Severity() Severity {
 	return e.severity
 }
 
-func (e *BaseError) Caller() Caller {
+func (e *BaseError) Caller() *Caller {
 	return e.caller
 }
 
@@ -70,6 +70,6 @@ func (e *BaseError) Enrich(args ...interface{}) {
 }
 
 // setCaller is used during the creation to set the caller
-func (e *BaseError) setCaller(caller Caller) {
+func (e *BaseError) setCaller(caller *Caller) {
 	e.caller = caller
 }

--- a/logging.go
+++ b/logging.go
@@ -1,15 +1,15 @@
 package sterrors
 
-var defaultFormatter Logger = &LogrusLogger{}
+var defaultLogger Logger = &LogrusLogger{}
 
 type Logger interface {
 	Log(err error)
 }
 
-func SetLogger(formatter Logger) {
-	defaultFormatter = formatter
+func SetLogger(logger Logger) {
+	defaultLogger = logger
 }
 
 func Log(err error) {
-	defaultFormatter.Log(err)
+	defaultLogger.Log(err)
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -17,7 +17,7 @@ func TestSetFormatter(t *testing.T) {
 	formatter := &TestLogFormatter{}
 	SetLogger(formatter)
 
-	assert.Equal(t, formatter, defaultFormatter)
+	assert.Equal(t, formatter, defaultLogger)
 }
 
 func TestLog(t *testing.T) {

--- a/stack.go
+++ b/stack.go
@@ -14,7 +14,7 @@ type Caller struct {
 type CallStackEntry struct {
 	ErrMessage string   `json:"msg,omitempty"`
 	Severity   Severity `json:"severity,omitempty"`
-	Caller     Caller   `json:"caller,omitempty"`
+	Caller     *Caller  `json:"caller,omitempty"`
 }
 
 // CallStack returns the callstack
@@ -42,7 +42,7 @@ func CallStack(err error) []CallStackEntry {
 	return res
 }
 
-func caller() Caller {
+func caller() *Caller {
 	pc, file, line, _ := runtime.Caller(2)
 	details := runtime.FuncForPC(pc)
 	nameSegments := strings.Split(details.Name(), "/")
@@ -50,5 +50,5 @@ func caller() Caller {
 	if len(nameSegments) > 0 {
 		funcName = nameSegments[len(nameSegments)-1]
 	}
-	return Caller{File: file, Line: line, FuncName: funcName}
+	return &Caller{File: file, Line: line, FuncName: funcName}
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -25,9 +25,10 @@ func TestCallStack(t *testing.T) {
 	assert.Equal(t, "second error", callStack[1].ErrMessage)
 	assert.Equal(t, "initial error", callStack[2].ErrMessage)
 
+	var nilCaller *Caller
 	assert.Equal(t, thirdCall, callStack[0].Caller)
 	assert.Equal(t, secondCall, callStack[1].Caller)
-	assert.Equal(t, Caller{}, callStack[2].Caller)
+	assert.Equal(t, nilCaller, callStack[2].Caller)
 }
 
 func TestCallStack_WithNotTraceableErr(t *testing.T) {

--- a/stack_test.go
+++ b/stack_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func callFake() Caller {
+func callFake() *Caller {
 	return caller()
 }
 


### PR DESCRIPTION
Make caller nil-able in stack trace, since unknown error types have no caller